### PR TITLE
remove sender; add reply-to when needed

### DIFF
--- a/index.js
+++ b/index.js
@@ -180,10 +180,13 @@ app.post('/message', function(request, response) {
 
   try {
     let data = JSON.parse(JSON.stringify(request.body))
-      // The From: address needs to be changed to use a verified domain
+      // The From: address needs to be changed to use a verified domain,
+      // and Sender removed (it could be changed as well, but that would make
+      // it redundant).
       // Note that jshint fails here due to a bug (https://github.com/jshint/jshint/pull/2881)
       , message = data[0].msys.relay_message.content.email_rfc822
-        .replace(/^From: .*$/m, 'From: ' + process.env.FORWARD_FROM);
+        .replace(/^From: .*$/m, 'From: ' + process.env.FORWARD_FROM)
+        .replace(/Sender: .*\r\n/, '');
 
     publisher.publish('queue', message);
 


### PR DESCRIPTION
Here's some things I noticed:
- currently, any incoming mail with a Sender field will cause an 'unconfigured sending domain' error when sending the transmission. I removed it. I don't know enough about the subtleties of sending emails to know whether this is something the backend should actually allow, but that might be worth looking into (my casual reading of the RFC suggests it's acceptable?)
- currently, the original From address is discarded, making it tough to reply to forwarded mail. I added a reply-to the original From if a reply-to isn't already present. (nb I tried using Resent- for this instead, but the backend doesn't allow it).

Normally I'd make separate PRs for something like this, but it's late :sleeping: 
